### PR TITLE
fix: allow globalThis fallback for this

### DIFF
--- a/src/konami-code.js
+++ b/src/konami-code.js
@@ -41,7 +41,7 @@
     if (typeof module === "object" && module.exports) {
         module.exports = factory;
     }
-}(this ?? globalThis, function callee(options) {
+}(this || globalThis, function callee(options) {
     var publics = this,
         privates = {},
         statics = callee;

--- a/src/konami-code.js
+++ b/src/konami-code.js
@@ -41,7 +41,7 @@
     if (typeof module === "object" && module.exports) {
         module.exports = factory;
     }
-}(this, function callee(options) {
+}(this ?? globalThis, function callee(options) {
     var publics = this,
         privates = {},
         statics = callee;


### PR DESCRIPTION
Fixes #3.

If `this` is not defined, I believe that means we can be sure we're in an environment with `globalThis` defined.